### PR TITLE
update to python 3.11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies and run tests with PyTest using Python 3.8
+# This workflow will install Python dependencies and run tests with PyTest using Python 3.11
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Run tests
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/checkout@v3
 
       # Set Python version
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       # Set up submodules and submodule dependencies
       # TODO: Uncomment when there are submodules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ jobs = 0
 
 # Minimum Python version to use for version dependent checks. Will default to the
 # version used to run pylint.
-py-version = "3.8"
+py-version = "3.11"
 
 # Discover python modules and packages in the file system subtree.
 recursive = true
@@ -105,7 +105,7 @@ addopts = "--ignore=modules/common/"
 
 [tool.black]
 line-length = 100
-target-version = ["py38"]
+target-version = ["py311"]
 # Excludes files or directories in addition to the defaults
 # Submodules
 extend-exclude = "modules/common/*"


### PR DESCRIPTION
Not thoroughly tested, since my linux doesn't have a camera (no immediate errors other than expected camera-finding issues). cv2 supports python 3.11, so it should be fine.